### PR TITLE
Add basic RSS functionality

### DIFF
--- a/fictionhub/chaoslegion/urls.py
+++ b/fictionhub/chaoslegion/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     url(r'^story/(?P<story>[^\.]+)/(?P<chapter>[^\.]+)/down$', views.chapter_down),
     url(r'^story/(?P<story>[^\.]+)/(?P<chapter>[^\.]+)/delete$', views.chapter_delete),        
     url(r'^story/(?P<story>[^\.]+)/edit$', views.story_edit),
+    url(r'^story/(?P<story>[^\.]+)/feed$', views.story_feed),
     url(r'^story/add$', views.story_create),                
     url(r'^story/(?P<story>[^\.]+)/add$', views.chapter_create),
     url(r'^story-create/$', views.story_create),

--- a/fictionhub/chaoslegion/views.py
+++ b/fictionhub/chaoslegion/views.py
@@ -299,6 +299,16 @@ def story_feed(request, story):
     desc = SubElement(channel,'description')
     desc.text = story.description
 
+    chapters = story.chapters.all()
+
+    for index in chapters:
+        item = SubElement(channel,'item')
+
+        title_c = SubElement(item,'title')
+        title_c.text = index.title
+        
+        link = SubElement(item,'link')
+        link.text = request.build_absolute_uri(index.get_absolute_url())
 
     return HttpResponse(tostring(rss, encoding='UTF-8'))
 

--- a/fictionhub/chaoslegion/views.py
+++ b/fictionhub/chaoslegion/views.py
@@ -2,10 +2,12 @@ import datetime
 from django.utils.timezone import utc
 import re
 import praw
+from xml.etree.ElementTree import Element, SubElement, tostring
 
 from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseRedirect, HttpResponse
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.core.urlresolvers import *
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
@@ -280,6 +282,27 @@ def post(request, slug):
         'hubs':hubs
     })
     
+
+def story_feed(request, story):
+    story = Story.objects.get(slug=story)
+    rss = Element('rss')
+    rss.set("version","2.0")
+
+    channel = SubElement(rss,'channel')
+
+    title = SubElement(channel,'title')
+    title.text = story.title
+
+    link = SubElement(channel,'link')
+    link.text = request.build_absolute_uri(reverse("story"))
+
+    desc = SubElement(channel,'description')
+    desc.text = story.description
+
+
+    return HttpResponse(tostring(rss, encoding='UTF-8'))
+
+
 
 # Edit post
 @login_required


### PR DESCRIPTION
append /feed to a story url to fetch it.  http://fictionhub.io/story/hacked/feed/ for example.  It is about as empty as it can be and still be valid, but it does validate with https://validator.w3.org/feed/check.cgi.  An example can be seen below.  I did format it, but for some reason it was removed.  

```<rss version="2.0">
    <channel>
        <title>Test</title>
        <link>http://localhost:8000/story/</link>
        <description>test</description>
        <item>
            <title>12</title>
            <link>http://localhost:8000/post/12</link>
        </item>
    </channel>
</rss>```