### PR TITLE
RSS Feed content type is now set as XML so it doesn't try to render a…

### DIFF
--- a/fictionhub/stories/views.py
+++ b/fictionhub/stories/views.py
@@ -797,7 +797,7 @@ def story_feed(request, story):
         title_c.text = index.title
         
         link = SubElement(item,'link')
-        link.text = request.build_absolute_uri(index.get_absolute_url())
-
-    return HttpResponse(tostring(rss, encoding='UTF-8'))
+        #link.text = request.build_absolute_uri(index.get_absolute_url())
+        link.text = "http://fictionhub.io/story/"+story.slug
+    return HttpResponse(tostring(rss, encoding='UTF-8'), content_type='application/xml')
 


### PR DESCRIPTION
…s HTML

This was bothering me a bit, so I fixed it.  